### PR TITLE
Refactor members in products

### DIFF
--- a/apps/server/prisma/faker-seeder.ts
+++ b/apps/server/prisma/faker-seeder.ts
@@ -49,14 +49,23 @@ function generateProductTypes() {
 function generateProduct(
   size: number = 1,
   opt: { typeSize: number },
-): Prisma.ProductCreateManyInput[] {
-  const products: Prisma.ProductCreateManyInput[] = [];
+): Prisma.ProductCreateInput[] {
+  const products: Prisma.ProductCreateInput[] = [];
   for (let i = 0; i < size; i++) {
     products.push({
       name: faker.lorem.sentence(),
       description: faker.lorem.paragraph(),
-      productTypeId: faker.number.int({ min: 1, max: opt.typeSize }),
+      type: {
+        connect: { id: faker.number.int({ min: 1, max: opt.typeSize }) },
+      },
       date: faker.date.past(),
+      members: {
+        connect: [
+          ...generateMemberConnection(
+            faker.number.int({ min: 1, max: PERSON_SIZE }),
+          ),
+        ],
+      },
     });
   }
   return products;
@@ -82,20 +91,9 @@ function generateProject(
         'InProgress',
       ]),
       products: {
-        createMany: {
-          data: [
-            ...generateProduct(PRODUCT_PER_PROJECT_SIZE, {
-              typeSize: TYPE_SIZE,
-            }),
-          ],
-        },
-      },
-      members: {
-        connect: [
-          ...generateMemberConnection(
-            faker.number.int({ min: 1, max: PERSON_SIZE }),
-          ),
-        ],
+        create: generateProduct(PRODUCT_PER_PROJECT_SIZE, {
+          typeSize: TYPE_SIZE,
+        }),
       },
     });
   }

--- a/apps/server/prisma/faker-seeder.ts
+++ b/apps/server/prisma/faker-seeder.ts
@@ -9,7 +9,7 @@ const CERT_ORG_SIZE = 4;
 const PROGRAM_SIZE = 5;
 const ROLE_SIZE = 2;
 const TYPE_SIZE = 4;
-const PERSON_SIZE = 400;
+const PERSON_SIZE = 300;
 const EVENT_SIZE = 10;
 const SEED_GROUP_SIZE = 50;
 const PRODUCT_PER_PROJECT_SIZE = faker.number.int({ min: 1, max: 10 });
@@ -60,11 +60,7 @@ function generateProduct(
       },
       date: faker.date.past(),
       members: {
-        connect: [
-          ...generateMemberConnection(
-            faker.number.int({ min: 1, max: PERSON_SIZE }),
-          ),
-        ],
+        connect: [...generateMemberConnection(5)],
       },
     });
   }
@@ -272,11 +268,14 @@ async function main() {
     }),
   ]);
 
-  createSeedGroup(SEED_GROUP_SIZE).forEach(async (seedGroup) => {
-    await prismaClient.seedGroup.create({
+  const sg = createSeedGroup(SEED_GROUP_SIZE);
+  const promises = sg.map((seedGroup) =>
+    prismaClient.seedGroup.create({
       data: seedGroup,
-    });
-  });
+    }),
+  );
+
+  await Promise.all(promises);
 }
 
 main()

--- a/apps/server/prisma/migrations/20231130184234_move_members_to_products/migration.sql
+++ b/apps/server/prisma/migrations/20231130184234_move_members_to_products/migration.sql
@@ -1,0 +1,49 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `projectId` on the `Product` table. All the data in the column will be lost.
+  - You are about to drop the `_PersonToProject` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Product" DROP CONSTRAINT "Product_projectId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_PersonToProject" DROP CONSTRAINT "_PersonToProject_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_PersonToProject" DROP CONSTRAINT "_PersonToProject_B_fkey";
+
+-- AlterTable
+ALTER TABLE "Product" DROP COLUMN "projectId",
+ADD COLUMN     "project_id" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "personId" INTEGER;
+
+-- DropTable
+DROP TABLE "_PersonToProject";
+
+-- CreateTable
+CREATE TABLE "_PersonToProduct" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PersonToProduct_AB_unique" ON "_PersonToProduct"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PersonToProduct_B_index" ON "_PersonToProduct"("B");
+
+-- AddForeignKey
+ALTER TABLE "Project" ADD CONSTRAINT "Project_personId_fkey" FOREIGN KEY ("personId") REFERENCES "directory"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "Project"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PersonToProduct" ADD CONSTRAINT "_PersonToProduct_A_fkey" FOREIGN KEY ("A") REFERENCES "directory"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PersonToProduct" ADD CONSTRAINT "_PersonToProduct_B_fkey" FOREIGN KEY ("B") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -82,6 +82,7 @@ model Person {
   LeaderRecord       LeaderRecord[]
   CoResearcherRecord CoResearcherRecord[]
   User               User[]
+  products           Product[]
 
   @@map("directory")
 }
@@ -139,9 +140,10 @@ model Project {
   certifyingOrganizationId Int                    @map("certifying_organization_id")
   approvedAmount           Float                  @map("approved_amount")
   products                 Product[]
-  members                  Person[]
   seedGroup                SeedGroup              @relation(fields: [seedGroupId], references: [id])
   seedGroupId              Int
+  Person                   Person?                @relation(fields: [personId], references: [id])
+  personId                 Int?
 }
 
 enum ProjectStatus {
@@ -162,7 +164,8 @@ model Product {
   type          ProductType @relation(fields: [productTypeId], references: [id])
   date          DateTime
   project       Project?    @relation(fields: [projectId], references: [id])
-  projectId     Int?
+  projectId     Int?        @map("project_id")
+  members       Person[]
   productTypeId Int         @map("productTypesId")
 }
 

--- a/apps/server/src/seed-groups/service/seed-group-repository/seed-group-repository.service.ts
+++ b/apps/server/src/seed-groups/service/seed-group-repository/seed-group-repository.service.ts
@@ -13,7 +13,14 @@ export class SeedGroupRepositoryService {
         id,
       },
       include: {
-        projects: { include: { certifyingOrganization: true, products: true } },
+        projects: {
+          include: {
+            certifyingOrganization: true,
+            products: {
+              include: { members: { select: { id: true, name: true } } },
+            },
+          },
+        },
       },
     });
   }
@@ -69,7 +76,14 @@ export class SeedGroupRepositoryService {
   async getSeedGroups() {
     return await this.prisma.seedGroup.findMany({
       include: {
-        projects: { include: { certifyingOrganization: true, products: true } },
+        projects: {
+          include: {
+            certifyingOrganization: true,
+            products: {
+              include: { members: { select: { id: true, name: true } } },
+            },
+          },
+        },
       },
     });
   }
@@ -97,8 +111,9 @@ export class SeedGroupRepositoryService {
         projects: {
           include: {
             certifyingOrganization: true,
-            products: true,
-            members: { select: { id: true, name: true } },
+            products: {
+              include: { members: { select: { id: true, name: true } } },
+            },
           },
         },
       },


### PR DESCRIPTION
This PR makes an important domain change to the database schema. Now the members belong to a product, not to a project. This allows us to show which products the person participated in.